### PR TITLE
衣橱恢复备份兼容ip版导出数据。

### DIFF
--- a/nikki.js
+++ b/nikki.js
@@ -444,7 +444,15 @@ function matches(c, criteria, filters) {
 }
 
 function loadCustomInventory() {
+
 	var myClothes = $("#myClothes").val();
+
+	// Ivangift's version uses "上衣" instead of "上装".
+	if (myClothes.indexOf("上衣:") > 0) {
+		myClothes = myClothes.replace("上衣:", "上装:");
+		$("#myClothes").text(myClothes);
+	}
+
 	if (myClothes.indexOf('|') > 0) {
 		loadNew(myClothes);
 	} else {


### PR DESCRIPTION
意念挖坟的ip君使用「上衣」，而不是「上装」，
因此导入ip版衣橱文本框文字后「上衣」组整组数据消失。

本提交增强了「恢复备份 」功能和ip版的兼容性。
方便从ip版迁移过来。

---

 nikki.js | 8 ++++++++
 1 file changed, 8 insertions(+)
